### PR TITLE
[Frontend] Gallery page with room classification sidebar

### DIFF
--- a/frontend/src/components/PhotoGrid.tsx
+++ b/frontend/src/components/PhotoGrid.tsx
@@ -1,0 +1,87 @@
+import { useState, type ReactNode } from 'react';
+import type { HousePhoto } from '../types';
+import { PhotoLightbox } from './PhotoLightbox';
+
+interface PhotoGridProps {
+  photos: HousePhoto[];
+  roomName: string;
+  isLoading?: boolean;
+}
+
+function PhotoGridSkeleton(): ReactNode {
+  return (
+    <div className="photo-grid photo-grid--loading" aria-busy="true" aria-label="Loading photos">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="photo-card photo-card--skeleton" />
+      ))}
+    </div>
+  );
+}
+
+export function PhotoGrid({ photos, roomName, isLoading = false }: PhotoGridProps): ReactNode {
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  if (isLoading) {
+    return <PhotoGridSkeleton />;
+  }
+
+  if (photos.length === 0) {
+    return (
+      <div className="photo-grid photo-grid--empty">
+        <p>No photos available for this room.</p>
+      </div>
+    );
+  }
+
+  const openLightbox = (index: number) => setLightboxIndex(index);
+  const closeLightbox = () => setLightboxIndex(null);
+  const prevPhoto = () =>
+    setLightboxIndex((i) => (i !== null && i > 0 ? i - 1 : i));
+  const nextPhoto = () =>
+    setLightboxIndex((i) => (i !== null && i < photos.length - 1 ? i + 1 : i));
+
+  return (
+    <>
+      <div
+        className="photo-grid"
+        role="list"
+        aria-label={`${roomName} photos`}
+      >
+        {photos.map((photo, index) => (
+          <div key={photo.id} className="photo-card" role="listitem">
+            <button
+              type="button"
+              className="photo-card__button"
+              onClick={() => openLightbox(index)}
+              aria-label={photo.caption ?? `${roomName} photo ${index + 1}`}
+            >
+              <img
+                className="photo-card__image"
+                src={photo.url}
+                srcSet={`${photo.url}?w=200 200w, ${photo.url}?w=400 400w`}
+                sizes="(max-width: 600px) 200px, 400px"
+                alt={photo.caption ?? `${roomName} photo ${index + 1}`}
+                loading="lazy"
+              />
+              {photo.isImaginedVersion && (
+                <span className="photo-card__badge" aria-label="Imagineered version">
+                  ✨ Imagineered
+                </span>
+              )}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {lightboxIndex !== null && (
+        <PhotoLightbox
+          photos={photos}
+          currentIndex={lightboxIndex}
+          onClose={closeLightbox}
+          onPrev={prevPhoto}
+          onNext={nextPhoto}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/PhotoLightbox.tsx
+++ b/frontend/src/components/PhotoLightbox.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import type { HousePhoto } from '../types';
+
+interface PhotoLightboxProps {
+  photos: HousePhoto[];
+  currentIndex: number;
+  onClose: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export function PhotoLightbox({
+  photos,
+  currentIndex,
+  onClose,
+  onPrev,
+  onNext,
+}: PhotoLightboxProps): ReactNode {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const photo = photos[currentIndex];
+
+  // Focus close button on open
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+  }, []);
+
+  // Keyboard navigation + focus trap
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === 'ArrowLeft') {
+        onPrev();
+        return;
+      }
+      if (e.key === 'ArrowRight') {
+        onNext();
+        return;
+      }
+      // Focus trap: Tab stays within dialog
+      if (e.key === 'Tab') {
+        const focusable = dialogRef.current?.querySelectorAll<HTMLElement>(
+          'button, [href], input, [tabindex]:not([tabindex="-1"])'
+        );
+        if (!focusable || focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, onPrev, onNext]);
+
+  if (!photo) return null;
+
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex < photos.length - 1;
+
+  return (
+    <div
+      className="lightbox"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Photo viewer"
+      ref={dialogRef}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <button
+        ref={closeButtonRef}
+        className="lightbox__close"
+        type="button"
+        onClick={onClose}
+        aria-label="Close photo viewer"
+      >
+        ✕
+      </button>
+
+      <div className="lightbox__content">
+        {hasPrev && (
+          <button
+            className="lightbox__nav lightbox__nav--prev"
+            type="button"
+            onClick={onPrev}
+            aria-label="Previous photo"
+          >
+            ‹
+          </button>
+        )}
+
+        <figure className="lightbox__figure">
+          <img
+            className="lightbox__image"
+            src={photo.url}
+            alt={photo.caption ?? 'Room photo'}
+          />
+          {photo.caption && (
+            <figcaption className="lightbox__caption">{photo.caption}</figcaption>
+          )}
+        </figure>
+
+        {hasNext && (
+          <button
+            className="lightbox__nav lightbox__nav--next"
+            type="button"
+            onClick={onNext}
+            aria-label="Next photo"
+          >
+            ›
+          </button>
+        )}
+      </div>
+
+      <div className="lightbox__counter" aria-live="polite">
+        {currentIndex + 1} / {photos.length}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RoomSidebar.tsx
+++ b/frontend/src/components/RoomSidebar.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react';
+import type { RoomClassification } from '../types';
+
+interface RoomSidebarProps {
+  rooms: RoomClassification[];
+  selectedRoomType: string | null;
+  onSelectRoom: (roomType: string) => void;
+  isLoading?: boolean;
+}
+
+function RoomSidebarSkeleton(): ReactNode {
+  return (
+    <nav className="room-sidebar room-sidebar--loading" aria-label="Room types">
+      <h3 className="room-sidebar__title">Rooms</h3>
+      <ul className="room-sidebar__list" role="list">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <li key={i} className="room-sidebar__item room-sidebar__item--skeleton">
+            <span className="room-sidebar__skeleton-label" />
+            <span className="room-sidebar__skeleton-badge" />
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+export function RoomSidebar({
+  rooms,
+  selectedRoomType,
+  onSelectRoom,
+  isLoading = false,
+}: RoomSidebarProps): ReactNode {
+  if (isLoading) {
+    return <RoomSidebarSkeleton />;
+  }
+
+  return (
+    <nav className="room-sidebar" aria-label="Room types">
+      <h3 className="room-sidebar__title">Rooms</h3>
+      <ul className="room-sidebar__list" role="list">
+        {rooms.map((room) => {
+          const isActive = room.roomType === selectedRoomType;
+          return (
+            <li key={room.roomType} className="room-sidebar__item">
+              <button
+                type="button"
+                className={`room-sidebar__button${isActive ? ' room-sidebar__button--active' : ''}`}
+                onClick={() => onSelectRoom(room.roomType)}
+                aria-current={isActive ? 'true' : undefined}
+              >
+                <span className="room-sidebar__room-name">
+                  {room.hasImaginedVersion && (
+                    <span className="room-sidebar__sparkle" aria-label="Has imagineered version">
+                      ✨{' '}
+                    </span>
+                  )}
+                  {room.displayName}
+                </span>
+                <span className="room-sidebar__badge" aria-label={`${room.photoCount} photos`}>
+                  {room.photoCount}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -2,3 +2,6 @@ export { Layout } from './Layout';
 export { Sidebar } from './Sidebar';
 export { ErrorBoundary } from './ErrorBoundary';
 export { Loading, LoadingOverlay } from './Loading';
+export { RoomSidebar } from './RoomSidebar';
+export { PhotoGrid } from './PhotoGrid';
+export { PhotoLightbox } from './PhotoLightbox';

--- a/frontend/src/hooks/useRoomClassifications.ts
+++ b/frontend/src/hooks/useRoomClassifications.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import type { RoomClassification } from '../types';
+
+interface UseRoomClassificationsResult {
+  data: RoomClassification[] | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+async function fetchRoomClassifications(houseId: string): Promise<RoomClassification[]> {
+  const res = await fetch(`/api/houses/${houseId}/room-classifications`);
+  if (!res.ok) throw new Error('Failed to fetch room classifications');
+  return res.json() as Promise<RoomClassification[]>;
+}
+
+export function useRoomClassifications(houseId: string | undefined): UseRoomClassificationsResult {
+  const [data, setData] = useState<RoomClassification[] | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!houseId) {
+      setData(undefined);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    setIsLoading(true);
+    setError(null);
+
+    fetchRoomClassifications(houseId)
+      .then((result) => {
+        if (!cancelled) {
+          setData(result);
+          setIsLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [houseId]);
+
+  return { data, isLoading, error };
+}

--- a/frontend/src/pages/GalleryPage.tsx
+++ b/frontend/src/pages/GalleryPage.tsx
@@ -1,12 +1,19 @@
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useParams, Link } from 'react-router-dom';
+import { useRoomClassifications } from '../hooks/useRoomClassifications';
+import { RoomSidebar } from '../components/RoomSidebar';
+import { PhotoGrid } from '../components/PhotoGrid';
 
-/**
- * Gallery page showing house photos with before/after comparison.
- * Placeholder until gallery component is implemented.
- */
+// CSS custom property for transitions
+const galleryStyle = {
+  '--transition-fast': '0.15s ease',
+} as React.CSSProperties;
+
 export function GalleryPage(): ReactNode {
   const { houseId } = useParams<{ houseId: string }>();
+  const [selectedRoomType, setSelectedRoomType] = useState<string | null>(null);
+
+  const { data: rooms, isLoading } = useRoomClassifications(houseId);
 
   if (!houseId) {
     return (
@@ -18,8 +25,12 @@ export function GalleryPage(): ReactNode {
     );
   }
 
+  const roomList = rooms ?? [];
+  const selectedRoom = roomList.find((r) => r.roomType === selectedRoomType) ?? roomList[0] ?? null;
+  const effectiveRoomType = selectedRoom?.roomType ?? null;
+
   return (
-    <div className="page page--gallery">
+    <div className="page page--gallery" style={galleryStyle}>
       <nav className="breadcrumb" aria-label="Breadcrumb">
         <Link to="/">Houses</Link>
         <span aria-hidden="true"> / </span>
@@ -29,12 +40,26 @@ export function GalleryPage(): ReactNode {
       </nav>
 
       <h2>Photo Gallery</h2>
-      <p className="placeholder-text">
-        Photo gallery for house <code>{houseId}</code> will appear here.
-        This will include the before/after image slider for imagineered rooms.
-      </p>
 
-      {/* GalleryViewer and BeforeAfterSlider components will be added in issues #4 and #5 */}
+      <div className="gallery-layout">
+        <div className="gallery-layout__sidebar">
+          <RoomSidebar
+            rooms={roomList}
+            selectedRoomType={effectiveRoomType}
+            onSelectRoom={setSelectedRoomType}
+            isLoading={isLoading}
+          />
+        </div>
+
+        <main className="gallery-layout__main" aria-label="Photo grid">
+          {/* BeforeAfterSlider will be integrated in issue #5 */}
+          <PhotoGrid
+            photos={selectedRoom?.photos ?? []}
+            roomName={selectedRoom?.displayName ?? 'Room'}
+            isLoading={isLoading}
+          />
+        </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/types/house.ts
+++ b/frontend/src/types/house.ts
@@ -57,3 +57,11 @@ export interface HouseListItem {
   listing: Pick<HouseListingDetails, 'price' | 'livingArea' | 'bedrooms'>;
   thumbnailUrl?: string;
 }
+
+export interface RoomClassification {
+  roomType: string;
+  displayName: string;
+  photoCount: number;
+  hasImaginedVersion: boolean;
+  photos: HousePhoto[];
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,4 +5,5 @@ export type {
   HouseListingDetails,
   HouseRoom,
   HousePhoto,
+  RoomClassification,
 } from './house';


### PR DESCRIPTION
## Summary

Implements issue #4: Gallery page showing house photos organized by room classification.

## What's included
- `RoomSidebar` — room type navigation with photo count badges and ✨ indicator for imagineered rooms. Skeleton loading state while data fetches.
- `PhotoGrid` — lazy-loaded image grid per room. Skeleton loading state. Empty state for rooms with no photos.
- `PhotoLightbox` — keyboard-navigable lightbox (Escape to close, arrow keys to navigate). Focus trap for accessibility.
- `useRoomClassifications` — simple fetch hook using useState + useEffect (no react-query). Cancellation via cleanup flag.
- `GalleryPage` — wired up with RoomSidebar + PhotoGrid + the hook.

## Approach
Build simple: plain fetch, plain React state, no heavy libraries.

Closes #4