### PR TITLE
chore: replace pip-audit dev dep with gh-action-pip-audit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,23 @@ jobs:
 
       - name: Test
         run: make test
+
+  pip-audit:
+    name: Security (pip-audit)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Export requirements
+        run: uv export --no-dev --format requirements-txt -o requirements.txt
+
+      - uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          inputs: backend/requirements.txt


### PR DESCRIPTION
## What

Moves security auditing from a local dev dependency to a dedicated CI job.

## Changes

- Removed `pip-audit` from `backend` dev dependencies
- Added a `pip-audit` job to `.github/workflows/ci.yml` using `pypa/gh-action-pip-audit@v1.1.0`
- Generates `requirements.txt` via `uv export --no-dev` so only production dependencies are audited