### PR TITLE
chore: add team directives — UV, no skip failures

### DIFF
--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -17,6 +17,18 @@ Decomposed Priority 1 work into 16 GitHub issues across 3 workstreams:
 - EXP-001 results will inform imagineering service defaults
 - Follows CLEAN architecture per ADRs
 
+### 2026-03-24: Use UV, not pip — all Python package management
+
+**By:** Terri Modrakowski (directive)
+
+All agents MUST use `uv` for Python dependency management — never `pip`. This aligns with ADR-002 which chose UV as the project's package manager. Commands: `uv pip install`, `uv sync`, `uv add` — never bare `pip install`.
+
+### 2026-03-24: Never skip lint or test failures — always fix
+
+**By:** Terri Modrakowski (directive)
+
+If a lint check, type check, or test fails, agents MUST fix the issue — never skip it, gloss over it, or bypass the hook. No `--no-verify`, no `SKIP=`, no "pre-existing issue" excuses. If it fails, fix it before proceeding.
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/.squad/decisions/inbox/coordinator-never-skip-failures.md
+++ b/.squad/decisions/inbox/coordinator-never-skip-failures.md
@@ -1,0 +1,5 @@
+### 2026-03-24: Never skip lint or test failures — always fix
+
+**By:** Terri Modrakowski (via Copilot)
+**What:** If a lint check, type check, or test fails, agents MUST fix the issue — never skip it, gloss over it, or bypass the hook. No `--no-verify`, no `SKIP=`, no "pre-existing issue" excuses. If it fails, fix it before proceeding.
+**Why:** User directive — quality gates are non-negotiable.

--- a/.squad/decisions/inbox/coordinator-use-uv-not-pip.md
+++ b/.squad/decisions/inbox/coordinator-use-uv-not-pip.md
@@ -1,0 +1,5 @@
+### 2026-03-24: Use UV, not pip — all Python package management
+
+**By:** Terri Modrakowski (via Copilot)
+**What:** All agents MUST use `uv` for Python dependency management — never `pip`. This aligns with ADR-002 which chose UV as the project's package manager. Commands: `uv pip install`, `uv sync`, `uv add` — never bare `pip install`.
+**Why:** User directive — reinforcing ADR-002. UV is the team standard.

--- a/.squad/decisions/inbox/zero-docker-setup.md
+++ b/.squad/decisions/inbox/zero-docker-setup.md
@@ -1,0 +1,15 @@
+# Decision: Docker Infrastructure Conventions
+
+**By:** Zero (Backend Dev) | **Date:** 2026-03-24 | **Issue:** #34 | **PR:** #36
+
+## Context
+Setting up Docker infrastructure for local dev required several conventions.
+
+## Decisions
+1. **uv via multi-stage copy** — `COPY --from=ghcr.io/astral-sh/uv:latest` instead of `pip install uv`. Keeps pip out of the build entirely per team directive.
+2. **nginx as API proxy** — Frontend nginx proxies `/api/` to `http://backend:8000/api/`. This means the frontend doesn't need CORS configuration and `VITE_API_BASE_URL=/api` works in both dev and Docker.
+3. **Volume mounts for data** — `input_data/` and `outputs/` are mounted as Docker volumes so local files flow through to the container without rebuilding.
+4. **Non-root runtime** — Backend container runs as `appuser` (uid 1000) for security.
+
+## Impact
+All team members can use `make docker-up` for local development. Frontend and backend services communicate via Docker networking.


### PR DESCRIPTION
## Team Directives

Two directives captured from Terri:

1. **Use UV, not pip** — All Python package management via `uv`. Aligns with ADR-002.
2. **Never skip lint/test failures** — If it fails, fix it. No `--no-verify`, no `SKIP=`, no excuses.

Also includes Docker setup decision from Zero.