### PR TITLE
feat: add imagineering service (FLUX.2-pro integration)

### DIFF
--- a/backend/prompts/imagineering_prompt.txt
+++ b/backend/prompts/imagineering_prompt.txt
@@ -1,0 +1,23 @@
+Edit the input image directly (do NOT recreate or reinterpret the room). Perform a localized furniture-only replacement on top of the existing pixels redecorated according to the instructions below.
+
+ABSOLUTE PRESERVATION — copy these PIXEL-FOR-PIXEL from the input:
+All permanent architectural elements must be copied deterministically from the input pixels without re-rendering or geometric reinterpretation (no diffusion applied to these regions).
+- WINDOWS: exact same shape, size, position, frame style, handles, glass panes, and mullions. Do not reshape, resize, add, or remove any window.
+- DOORS: exact same shape, position, handle style, and frame.
+- WALLS: exact same colour, texture, and position. Do not repaint or retexture.
+- CEILING: exact same colour, texture, beams, or moulding.
+- FLOOR: exact same material, colour, and pattern.
+- RADIATORS & HEATING: exact same style, size, and position.
+- LIGHT FIXTURES: exact same ceiling lights, wall lights, and switches in the same positions.
+- ROOM PROPORTIONS: exact same perspective, camera angle, and field of view.
+
+ITEMS YOU MUST REPLACE / CHANGE (these are NOT permanent fixtures):
+- Beds, bed frames, bed railings, mattresses, bedding, pillows
+- Wardrobes, closets, dressers, shelving units, bookcases
+- Desks, tables, chairs, sofas, armchairs
+- Curtains, blinds (window frame stays, fabric can change)
+- Rugs, lamps (floor/table lamps only — ceiling lights stay), accessories, wall art, plants
+
+Think of it as: remove ONLY movable furniture via inpainting while the architectural background layer remains pixel-locked. Now furnish and decorate it according to the instructions, while the room shell (walls, windows, doors, floor, ceiling, radiators, fixed lights) remains photographically identical to the input.
+
+Reimagine this $room_type with a fresh, modern style. Replace all movable furniture and decor while keeping the room's architectural elements identical. Use a cohesive color palette and contemporary design choices appropriate for a $room_type.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "openai>=2.29.0",
     "pydantic>=2.6.0",
     "pyyaml>=6.0",
+    "requests>=2.31.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/core.py
+++ b/backend/src/core.py
@@ -6,9 +6,11 @@ import os
 
 from .config import load_storage_paths
 from .interfaces.data_source import IDataSource
+from .interfaces.imagineering import IImagineeringService
 from .interfaces.room_classifier import IRoomClassifier
 from .services.azure_openai_service import AzureOpenAIService
 from .services.house_repository import HouseRepository
+from .services.imagineering_service import FluxImagineeringService
 from .services.local_storage import LocalStorage
 from .services.room_classifier import AzureOpenAIRoomClassifier
 
@@ -55,4 +57,37 @@ def create_room_classifier() -> IRoomClassifier:
         input_dir=input_dir,
         output_dir=output_dir,
         batch_size=batch_size,
+    )
+
+
+def create_imagineering_service() -> IImagineeringService:
+    """Create an imagineering service wired to FLUX.2-pro and storage paths.
+
+    Reads FLUX_API_KEY, FLUX_ENDPOINT, and FLUX_GUIDANCE from environment
+    variables. All three are required — missing values raise RuntimeError.
+    FLUX_SEED is optional (defaults to random per-image).
+
+    Returns:
+        A configured IImagineeringService implementation.
+
+    Raises:
+        RuntimeError: If required FLUX environment variables are missing.
+    """
+    missing = [
+        name
+        for name in ("FLUX_API_KEY", "FLUX_ENDPOINT", "FLUX_GUIDANCE")
+        if not os.environ.get(name)
+    ]
+    if missing:
+        raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")
+
+    input_dir, output_dir = load_storage_paths()
+    seed_raw = os.environ.get("FLUX_SEED")
+    return FluxImagineeringService(
+        api_key=os.environ["FLUX_API_KEY"],
+        endpoint=os.environ["FLUX_ENDPOINT"],
+        input_dir=input_dir,
+        output_dir=output_dir,
+        guidance=float(os.environ["FLUX_GUIDANCE"]),
+        default_seed=int(seed_raw) if seed_raw is not None else None,
     )

--- a/backend/src/interfaces/__init__.py
+++ b/backend/src/interfaces/__init__.py
@@ -6,12 +6,14 @@ Implementations live in services/.
 
 from .data_source import IDataSource
 from .filter import IFilter
+from .imagineering import IImagineeringService
 from .llm_service import ILLMService
 from .room_classifier import IRoomClassifier
 
 __all__ = [
     "IDataSource",
     "IFilter",
+    "IImagineeringService",
     "ILLMService",
     "IRoomClassifier",
 ]

--- a/backend/src/interfaces/imagineering.py
+++ b/backend/src/interfaces/imagineering.py
@@ -1,0 +1,25 @@
+"""IImagineeringService abstract base class for room image reimagining."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..models.imagineering import ImagineeringResult
+
+
+class IImagineeringService(ABC):
+    """Abstract base class for room imagineering operations."""
+
+    @abstractmethod
+    def imagineer_house(self, slug: str) -> ImagineeringResult:
+        """Reimagine all classified rooms for a single house.
+
+        Reads room classifications from the output directory, generates
+        reimagined images using a generative model, and saves results.
+
+        Args:
+            slug: House identifier (folder name under input_dir/houses/).
+
+        Returns:
+            ImagineeringResult with per-photo generation results.
+        """

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -6,6 +6,7 @@ and focused on data representation.
 
 from .classification import HouseClassifications, PhotoClassification
 from .house import FilterResult, House, HouseMetadata, HouseStatus
+from .imagineering import ImagineeringPhoto, ImagineeringResult
 from .llm import LLMResponse
 from .room import Photo, Room, RoomType
 
@@ -15,6 +16,8 @@ __all__ = [
     "HouseClassifications",
     "HouseMetadata",
     "HouseStatus",
+    "ImagineeringPhoto",
+    "ImagineeringResult",
     "LLMResponse",
     "Photo",
     "PhotoClassification",

--- a/backend/src/models/imagineering.py
+++ b/backend/src/models/imagineering.py
@@ -1,0 +1,35 @@
+"""Imagineering result models.
+
+Pure data structures for FLUX.2-pro image generation outputs.
+Used by the imagineering service to represent per-photo
+and per-house generation results.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ImagineeringPhoto(BaseModel):
+    """Generation result for a single photo."""
+
+    filename: str = Field(description="Original photo filename")
+    room_type: str = Field(description="Classified room type")
+    prompt_used: str = Field(description="FLUX prompt used for generation")
+    guidance_value: float = Field(description="Guidance scale used")
+    output_path: str = Field(description="Relative path to generated image")
+    timestamp: str = Field(description="ISO 8601 generation timestamp")
+
+    model_config = {"frozen": True}
+
+
+class ImagineeringResult(BaseModel):
+    """All imagineering results for a single house."""
+
+    slug: str = Field(description="House identifier")
+    photos: list[ImagineeringPhoto] = Field(
+        default_factory=list,
+        description="Per-photo generation results",
+    )
+
+    model_config = {"frozen": True}

--- a/backend/src/services/__init__.py
+++ b/backend/src/services/__init__.py
@@ -1,7 +1,13 @@
 """Concrete implementations of pipeline interfaces."""
 
 from .azure_openai_service import AzureOpenAIService
+from .imagineering_service import FluxImagineeringService
 from .local_storage import LocalStorage
 from .room_classifier import AzureOpenAIRoomClassifier
 
-__all__ = ["AzureOpenAIService", "AzureOpenAIRoomClassifier", "LocalStorage"]
+__all__ = [
+    "AzureOpenAIService",
+    "AzureOpenAIRoomClassifier",
+    "FluxImagineeringService",
+    "LocalStorage",
+]

--- a/backend/src/services/imagineering_service.py
+++ b/backend/src/services/imagineering_service.py
@@ -1,0 +1,322 @@
+"""Imagineering service — generates reimagined room images using FLUX.2-pro.
+
+Reads room classifications from outputs/houses/{slug}/room_classifications.json,
+generates reimagined images via the FLUX.2-pro API, and writes results to
+outputs/houses/{slug}/imagineered/{room_type}/{photo}.png.
+
+Uses exponential backoff for API retries. Idempotent — skips already-generated images.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import random
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from string import Template
+
+import requests
+
+from ..interfaces.imagineering import IImagineeringService
+from ..models.imagineering import ImagineeringPhoto, ImagineeringResult
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+
+_PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
+
+_MAX_RETRIES = 5
+_BASE_DELAY = 2.0
+_MAX_DELAY = 120.0
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+_REQUEST_TIMEOUT = 300
+
+
+class FluxImagineeringService(IImagineeringService):
+    """Generates reimagined room images via the FLUX.2-pro API.
+
+    Args:
+        api_key: Bearer token for the FLUX API.
+        endpoint: FLUX.2-pro endpoint URL.
+        input_dir: Root directory containing house input data.
+        output_dir: Root directory for imagineering output.
+        guidance: Guidance scale for image generation.
+        default_seed: Default seed for reproducibility (None = random).
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        endpoint: str,
+        input_dir: Path,
+        output_dir: Path,
+        guidance: float,
+        default_seed: int | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._endpoint = endpoint
+        self._input_dir = input_dir
+        self._output_dir = output_dir
+        self._guidance = guidance
+        self._default_seed = default_seed
+        self._prompt_template = Template(
+            (_PROMPTS_DIR / "imagineering_prompt.txt").read_text(encoding="utf-8")
+        )
+
+    def imagineer_house(self, slug: str) -> ImagineeringResult:
+        """Reimagine all classified rooms for a single house.
+
+        Reads room classifications, generates reimagined images for each photo,
+        and writes results to the output directory. Skips already-generated images.
+
+        Args:
+            slug: House identifier (folder name under input_dir/houses/).
+
+        Returns:
+            ImagineeringResult with per-photo generation results.
+        """
+        classifications = self._load_classifications(slug)
+        if not classifications:
+            logger.warning("No classifications found for house '%s'", slug)
+            return ImagineeringResult(slug=slug)
+
+        results_file = self._output_dir / "houses" / slug / "imagineering_results.json"
+        existing = self._load_previous_results(results_file)
+        already_done = {p.filename for p in existing}
+
+        to_process = [c for c in classifications if c["filename"] not in already_done]
+        if not to_process:
+            logger.info(
+                "All %d photos already imagineered for '%s'",
+                len(classifications),
+                slug,
+            )
+            return ImagineeringResult(slug=slug, photos=existing)
+
+        logger.info(
+            "Imagineering %d new photos for '%s' (%d already done)",
+            len(to_process),
+            slug,
+            len(already_done),
+        )
+
+        new_photos: list[ImagineeringPhoto] = []
+        for entry in to_process:
+            photo = self._imagineer_photo(slug, entry)
+            if photo is not None:
+                new_photos.append(photo)
+
+        all_photos = existing + new_photos
+        result = ImagineeringResult(slug=slug, photos=all_photos)
+        self._save_results(results_file, result)
+
+        logger.info(
+            "Imagineered %d photos for '%s' (%d new)",
+            len(all_photos),
+            slug,
+            len(new_photos),
+        )
+        return result
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load_classifications(self, slug: str) -> list[dict]:
+        """Load room classifications from the output directory.
+
+        Args:
+            slug: House identifier.
+
+        Returns:
+            List of classification dicts with filename and room_type keys.
+        """
+        classifications_file = self._output_dir / "houses" / slug / "room_classifications.json"
+        if not classifications_file.exists():
+            return []
+
+        try:
+            data = json.loads(classifications_file.read_text(encoding="utf-8"))
+            return data.get("classifications", [])
+        except (json.JSONDecodeError, KeyError) as exc:
+            logger.warning("Corrupt classifications file %s: %s", classifications_file, exc)
+            return []
+
+    def _imagineer_photo(self, slug: str, classification: dict) -> ImagineeringPhoto | None:
+        """Generate a reimagined image for a single photo.
+
+        Args:
+            slug: House identifier.
+            classification: Dict with filename and room_type.
+
+        Returns:
+            ImagineeringPhoto result, or None if the source photo is missing.
+        """
+        filename = classification["filename"]
+        room_type = classification["room_type"]
+
+        source_path = self._input_dir / "houses" / slug / "photos" / filename
+        if not source_path.exists():
+            logger.warning("Source photo not found: %s", source_path)
+            return None
+
+        prompt = self._prompt_template.substitute(room_type=room_type)
+        seed = self._default_seed if self._default_seed is not None else random.randint(0, 2**31)
+
+        image_bytes = source_path.read_bytes()
+        generated = self._call_flux_api(
+            image_bytes=image_bytes,
+            prompt=prompt,
+            guidance=self._guidance,
+            seed=seed,
+        )
+
+        output_stem = Path(filename).stem
+        output_path = (
+            self._output_dir / "houses" / slug / "imagineered" / room_type / f"{output_stem}.png"
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(generated)
+
+        timestamp = datetime.now(timezone.utc).isoformat()
+        relative_output = str(output_path.relative_to(self._output_dir))
+
+        logger.info("Generated %s → %s", filename, relative_output)
+        return ImagineeringPhoto(
+            filename=filename,
+            room_type=room_type,
+            prompt_used=prompt,
+            guidance_value=self._guidance,
+            output_path=relative_output,
+            timestamp=timestamp,
+        )
+
+    def _call_flux_api(
+        self,
+        *,
+        image_bytes: bytes,
+        prompt: str,
+        guidance: float,
+        seed: int,
+    ) -> bytes:
+        """Call the FLUX.2-pro API with exponential backoff retries.
+
+        Args:
+            image_bytes: Raw bytes of the source image.
+            prompt: Generation prompt.
+            guidance: Guidance scale.
+            seed: Random seed for reproducibility.
+
+        Returns:
+            Raw PNG bytes of the generated image.
+
+        Raises:
+            RuntimeError: If the API call fails after all retries.
+        """
+        url = f"{self._endpoint}?api-version=preview"
+        b64_image = base64.b64encode(image_bytes).decode("utf-8")
+
+        body = {
+            "prompt": prompt,
+            "model": "FLUX.2-pro",
+            "n": 1,
+            "width": 1024,
+            "height": 1024,
+            "guidance": guidance,
+            "steps": 50,
+            "seed": seed,
+            "input_image": b64_image,
+        }
+
+        last_error: str | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                resp = requests.post(
+                    url,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Authorization": f"Bearer {self._api_key}",
+                    },
+                    json=body,
+                    timeout=_REQUEST_TIMEOUT,
+                )
+
+                if resp.ok:
+                    data = resp.json().get("data", [])
+                    if not data or "b64_json" not in data[0]:
+                        raise RuntimeError(f"Unexpected FLUX response shape: {resp.text[:500]}")
+                    return base64.b64decode(data[0]["b64_json"])
+
+                if resp.status_code in _RETRYABLE_STATUS_CODES:
+                    delay = min(_BASE_DELAY * (2**attempt), _MAX_DELAY) + random.uniform(0, 1)
+                    logger.warning(
+                        "FLUX API %d, retrying in %.1fs (attempt %d/%d)",
+                        resp.status_code,
+                        delay,
+                        attempt + 1,
+                        _MAX_RETRIES + 1,
+                    )
+                    time.sleep(delay)
+                    last_error = f"HTTP {resp.status_code}: {resp.text[:300]}"
+                    continue
+
+                resp.raise_for_status()
+
+            except requests.RequestException as exc:
+                if attempt < _MAX_RETRIES:
+                    delay = min(_BASE_DELAY * (2**attempt), _MAX_DELAY)
+                    logger.warning("FLUX API error: %s — retrying in %.1fs", exc, delay)
+                    time.sleep(delay)
+                    last_error = str(exc)
+                else:
+                    raise RuntimeError(
+                        f"FLUX request failed after {_MAX_RETRIES + 1} attempts: {exc}"
+                    ) from exc
+
+        raise RuntimeError(f"FLUX request failed after {_MAX_RETRIES + 1} attempts: {last_error}")
+
+    @staticmethod
+    def _load_previous_results(results_file: Path) -> list[ImagineeringPhoto]:
+        """Load previously saved imagineering results for idempotent re-runs.
+
+        Args:
+            results_file: Path to the imagineering_results.json file.
+
+        Returns:
+            List of previously saved ImagineeringPhoto objects, or empty list.
+        """
+        if not results_file.exists():
+            return []
+
+        try:
+            data = json.loads(results_file.read_text(encoding="utf-8"))
+            return [ImagineeringPhoto(**entry) for entry in data.get("photos", [])]
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
+            logger.warning(
+                "Corrupt imagineering results file %s, re-generating: %s",
+                results_file,
+                exc,
+            )
+            return []
+
+    @staticmethod
+    def _save_results(results_file: Path, result: ImagineeringResult) -> None:
+        """Persist imagineering results to JSON.
+
+        Args:
+            results_file: Destination path for imagineering_results.json.
+            result: Imagineering results to persist.
+        """
+        results_file.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "slug": result.slug,
+            "photos": [photo.model_dump() for photo in result.photos],
+        }
+        results_file.write_text(
+            json.dumps(payload, indent=2) + "\n",
+            encoding="utf-8",
+        )

--- a/backend/tests/test_imagineering.py
+++ b/backend/tests/test_imagineering.py
@@ -1,0 +1,493 @@
+"""Unit tests for the imagineering service."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import NamedTuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.models.imagineering import ImagineeringPhoto, ImagineeringResult
+from src.services.imagineering_service import FluxImagineeringService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_API_KEY = "test-key"
+_FAKE_ENDPOINT = "https://flux.example.com/generate"
+_FAKE_GUIDANCE = 15.0
+_FAKE_SEED = 42
+
+# 1x1 white PNG for testing (smallest valid PNG)
+_TINY_PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01"
+    b"\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde\x00"
+    b"\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00"
+    b"\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+def _make_flux_response(image_bytes: bytes = _TINY_PNG) -> dict:
+    """Build a fake FLUX API JSON response."""
+    return {"data": [{"b64_json": base64.b64encode(image_bytes).decode("utf-8")}]}
+
+
+def _setup_house(
+    tmp_path: Path, slug: str, filenames: list[str], room_type: str = "bedroom"
+) -> tuple[Path, Path]:
+    """Create input photos and a classifications file in tmp_path.
+
+    Returns:
+        (input_dir, output_dir) paths.
+    """
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    photos_dir = input_dir / "houses" / slug / "photos"
+    photos_dir.mkdir(parents=True)
+    for name in filenames:
+        (photos_dir / name).write_bytes(_TINY_PNG)
+
+    classifications = {
+        "slug": slug,
+        "classifications": [
+            {"filename": name, "room_type": room_type, "confidence": 0.9} for name in filenames
+        ],
+    }
+    cls_dir = output_dir / "houses" / slug
+    cls_dir.mkdir(parents=True)
+    (cls_dir / "room_classifications.json").write_text(
+        json.dumps(classifications, indent=2) + "\n", encoding="utf-8"
+    )
+
+    return input_dir, output_dir
+
+
+def _make_service(input_dir: Path, output_dir: Path) -> FluxImagineeringService:
+    """Create a FluxImagineeringService with test defaults."""
+    return FluxImagineeringService(
+        api_key=_FAKE_API_KEY,
+        endpoint=_FAKE_ENDPOINT,
+        input_dir=input_dir,
+        output_dir=output_dir,
+        guidance=_FAKE_GUIDANCE,
+        default_seed=_FAKE_SEED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model serialization
+# ---------------------------------------------------------------------------
+
+
+class ModelSerializationCase(NamedTuple):
+    """Test case for model round-trip serialization."""
+
+    description: str
+    photo: ImagineeringPhoto
+    expected_room_type: str
+
+
+MODEL_SERIALIZATION_CASES = [
+    ModelSerializationCase(
+        description="ImagineeringPhoto round-trips through dict serialization",
+        photo=ImagineeringPhoto(
+            filename="test.jpg",
+            room_type="bedroom",
+            prompt_used="test prompt",
+            guidance_value=15.0,
+            output_path="houses/test/imagineered/bedroom/test.png",
+            timestamp="2026-03-24T00:00:00+00:00",
+        ),
+        expected_room_type="bedroom",
+    ),
+    ModelSerializationCase(
+        description="ImagineeringPhoto preserves kitchen room type",
+        photo=ImagineeringPhoto(
+            filename="kitchen.jpg",
+            room_type="kitchen",
+            prompt_used="reimagine kitchen",
+            guidance_value=20.0,
+            output_path="houses/test/imagineered/kitchen/kitchen.png",
+            timestamp="2026-03-24T12:00:00+00:00",
+        ),
+        expected_room_type="kitchen",
+    ),
+]
+
+
+@pytest.mark.parametrize("description, photo, expected_room_type", MODEL_SERIALIZATION_CASES)
+def test_model_serialization(
+    description: str,
+    photo: ImagineeringPhoto,
+    expected_room_type: str,
+) -> None:
+    data = photo.model_dump()
+    restored = ImagineeringPhoto(**data)
+    assert restored.room_type == expected_room_type
+    assert restored == photo
+
+
+# ---------------------------------------------------------------------------
+# ImagineeringResult container
+# ---------------------------------------------------------------------------
+
+
+class ResultContainerCase(NamedTuple):
+    """Test case for ImagineeringResult."""
+
+    description: str
+    slug: str
+    photo_count: int
+
+
+RESULT_CONTAINER_CASES = [
+    ResultContainerCase(
+        description="empty result has no photos",
+        slug="test-house",
+        photo_count=0,
+    ),
+    ResultContainerCase(
+        description="result holds multiple photos",
+        slug="my-house",
+        photo_count=3,
+    ),
+]
+
+
+@pytest.mark.parametrize("description, slug, photo_count", RESULT_CONTAINER_CASES)
+def test_result_container(description: str, slug: str, photo_count: int) -> None:
+    photos = [
+        ImagineeringPhoto(
+            filename=f"photo_{i}.jpg",
+            room_type="bedroom",
+            prompt_used="prompt",
+            guidance_value=15.0,
+            output_path=f"houses/{slug}/imagineered/bedroom/photo_{i}.png",
+            timestamp="2026-03-24T00:00:00+00:00",
+        )
+        for i in range(photo_count)
+    ]
+    result = ImagineeringResult(slug=slug, photos=photos)
+    assert result.slug == slug
+    assert len(result.photos) == photo_count
+
+
+# ---------------------------------------------------------------------------
+# Service — successful generation
+# ---------------------------------------------------------------------------
+
+
+class GenerationCase(NamedTuple):
+    """Test case for successful image generation."""
+
+    description: str
+    filenames: list[str]
+    room_type: str
+    expected_output_count: int
+
+
+GENERATION_CASES = [
+    GenerationCase(
+        description="single photo generates one output",
+        filenames=["photo1.jpg"],
+        room_type="bedroom",
+        expected_output_count=1,
+    ),
+    GenerationCase(
+        description="multiple photos each generate one output",
+        filenames=["a.jpg", "b.png"],
+        room_type="kitchen",
+        expected_output_count=2,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "description, filenames, room_type, expected_output_count", GENERATION_CASES
+)
+def test_generation_success(
+    tmp_path: Path,
+    description: str,
+    filenames: list[str],
+    room_type: str,
+    expected_output_count: int,
+) -> None:
+    input_dir, output_dir = _setup_house(tmp_path, "test-house", filenames, room_type)
+    service = _make_service(input_dir, output_dir)
+
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_resp.json.return_value = _make_flux_response()
+
+    with patch("src.services.imagineering_service.requests.post", return_value=mock_resp):
+        result = service.imagineer_house("test-house")
+
+    assert len(result.photos) == expected_output_count
+    for photo in result.photos:
+        assert photo.room_type == room_type
+        assert photo.guidance_value == _FAKE_GUIDANCE
+        output_file = output_dir / photo.output_path
+        assert output_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Service — idempotent behavior
+# ---------------------------------------------------------------------------
+
+
+class IdempotentCase(NamedTuple):
+    """Test case for idempotent generation skipping."""
+
+    description: str
+    already_done: list[str]
+    all_files: list[str]
+    expected_new_calls: int
+    expected_total: int
+
+
+IDEMPOTENT_CASES = [
+    IdempotentCase(
+        description="skips already-generated photos",
+        already_done=["photo1.jpg"],
+        all_files=["photo1.jpg", "photo2.jpg"],
+        expected_new_calls=1,
+        expected_total=2,
+    ),
+    IdempotentCase(
+        description="no API calls when all photos are done",
+        already_done=["a.jpg", "b.jpg"],
+        all_files=["a.jpg", "b.jpg"],
+        expected_new_calls=0,
+        expected_total=2,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "description, already_done, all_files, expected_new_calls, expected_total",
+    IDEMPOTENT_CASES,
+)
+def test_idempotent_behavior(
+    tmp_path: Path,
+    description: str,
+    already_done: list[str],
+    all_files: list[str],
+    expected_new_calls: int,
+    expected_total: int,
+) -> None:
+    input_dir, output_dir = _setup_house(tmp_path, "test-house", all_files)
+    service = _make_service(input_dir, output_dir)
+
+    # Write pre-existing results
+    existing_photos = [
+        {
+            "filename": name,
+            "room_type": "bedroom",
+            "prompt_used": "old prompt",
+            "guidance_value": 15.0,
+            "output_path": f"houses/test-house/imagineered/bedroom/{Path(name).stem}.png",
+            "timestamp": "2026-03-24T00:00:00+00:00",
+        }
+        for name in already_done
+    ]
+    results_file = output_dir / "houses" / "test-house" / "imagineering_results.json"
+    results_file.write_text(
+        json.dumps({"slug": "test-house", "photos": existing_photos}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_resp.json.return_value = _make_flux_response()
+
+    with patch(
+        "src.services.imagineering_service.requests.post", return_value=mock_resp
+    ) as mock_post:
+        result = service.imagineer_house("test-house")
+
+    assert mock_post.call_count == expected_new_calls
+    assert len(result.photos) == expected_total
+
+
+# ---------------------------------------------------------------------------
+# Service — API error handling
+# ---------------------------------------------------------------------------
+
+
+class APIErrorCase(NamedTuple):
+    """Test case for API error handling."""
+
+    description: str
+    status_code: int
+    is_retryable: bool
+
+
+API_ERROR_CASES = [
+    APIErrorCase(
+        description="429 triggers retries then fails",
+        status_code=429,
+        is_retryable=True,
+    ),
+    APIErrorCase(
+        description="500 triggers retries then fails",
+        status_code=500,
+        is_retryable=True,
+    ),
+    APIErrorCase(
+        description="400 fails immediately without retry",
+        status_code=400,
+        is_retryable=False,
+    ),
+]
+
+
+@pytest.mark.parametrize("description, status_code, is_retryable", API_ERROR_CASES)
+def test_api_error_handling(
+    tmp_path: Path,
+    description: str,
+    status_code: int,
+    is_retryable: bool,
+) -> None:
+    input_dir, output_dir = _setup_house(tmp_path, "test-house", ["photo.jpg"])
+    service = _make_service(input_dir, output_dir)
+
+    mock_resp = MagicMock()
+    mock_resp.ok = False
+    mock_resp.status_code = status_code
+    mock_resp.text = f"Error {status_code}"
+    mock_resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+
+    with (
+        patch("src.services.imagineering_service.requests.post", return_value=mock_resp),
+        patch("src.services.imagineering_service.time.sleep"),
+        pytest.raises((RuntimeError, Exception)),
+    ):
+        service.imagineer_house("test-house")
+
+
+# ---------------------------------------------------------------------------
+# Service — missing classifications
+# ---------------------------------------------------------------------------
+
+
+class MissingDataCase(NamedTuple):
+    """Test case for missing input data."""
+
+    description: str
+    has_classifications: bool
+    expected_photo_count: int
+
+
+MISSING_DATA_CASES = [
+    MissingDataCase(
+        description="no classifications file returns empty result",
+        has_classifications=False,
+        expected_photo_count=0,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "description, has_classifications, expected_photo_count", MISSING_DATA_CASES
+)
+def test_missing_data(
+    tmp_path: Path,
+    description: str,
+    has_classifications: bool,
+    expected_photo_count: int,
+) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    if has_classifications:
+        cls_dir = output_dir / "houses" / "test-house"
+        cls_dir.mkdir(parents=True)
+        (cls_dir / "room_classifications.json").write_text(
+            json.dumps({"slug": "test-house", "classifications": []}) + "\n"
+        )
+
+    service = _make_service(input_dir, output_dir)
+    result = service.imagineer_house("test-house")
+    assert len(result.photos) == expected_photo_count
+
+
+# ---------------------------------------------------------------------------
+# Service — missing source photo
+# ---------------------------------------------------------------------------
+
+
+def test_missing_source_photo_skipped(tmp_path: Path) -> None:
+    """Photos referenced in classifications but missing on disk are skipped."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    # Create classifications referencing a photo that doesn't exist on disk
+    cls_dir = output_dir / "houses" / "test-house"
+    cls_dir.mkdir(parents=True)
+    (cls_dir / "room_classifications.json").write_text(
+        json.dumps(
+            {
+                "slug": "test-house",
+                "classifications": [
+                    {"filename": "ghost.jpg", "room_type": "bedroom", "confidence": 0.9}
+                ],
+            }
+        )
+        + "\n"
+    )
+
+    # Don't create the photos directory at all
+    service = _make_service(input_dir, output_dir)
+    result = service.imagineer_house("test-house")
+    assert len(result.photos) == 0
+
+
+# ---------------------------------------------------------------------------
+# Factory — create_imagineering_service
+# ---------------------------------------------------------------------------
+
+
+class FactoryEnvCase(NamedTuple):
+    """Test case for create_imagineering_service env var validation."""
+
+    description: str
+    env_vars: dict[str, str]
+    should_raise: bool
+
+
+FACTORY_ENV_CASES = [
+    FactoryEnvCase(
+        description="missing FLUX_API_KEY raises RuntimeError",
+        env_vars={"FLUX_ENDPOINT": "https://x", "FLUX_GUIDANCE": "15"},
+        should_raise=True,
+    ),
+    FactoryEnvCase(
+        description="missing FLUX_ENDPOINT raises RuntimeError",
+        env_vars={"FLUX_API_KEY": "key", "FLUX_GUIDANCE": "15"},
+        should_raise=True,
+    ),
+    FactoryEnvCase(
+        description="missing FLUX_GUIDANCE raises RuntimeError",
+        env_vars={"FLUX_API_KEY": "key", "FLUX_ENDPOINT": "https://x"},
+        should_raise=True,
+    ),
+]
+
+
+@pytest.mark.parametrize("description, env_vars, should_raise", FACTORY_ENV_CASES)
+def test_factory_env_validation(
+    description: str, env_vars: dict[str, str], should_raise: bool
+) -> None:
+    from src.core import create_imagineering_service
+
+    with patch.dict("os.environ", env_vars, clear=True):
+        if should_raise:
+            with pytest.raises(RuntimeError, match="Missing required environment"):
+                create_imagineering_service()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -34,6 +34,79 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6", size = 143363, upload-time = "2026-03-15T18:53:25.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/62/c0815c992c9545347aeea7859b50dc9044d147e2e7278329c6e02ac9a616/charset_normalizer-3.4.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ef7fedc7a6ecbe99969cd09632516738a97eeb8bd7258bf8a0f23114c057dab", size = 295154, upload-time = "2026-03-15T18:50:50.88Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/bdca6613c2e3c58c7421891d80cc3efa1d32e882f7c4a7ee6039c3fc951a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21", size = 199191, upload-time = "2026-03-15T18:50:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/92/9934d1bbd69f7f398b38c5dae1cbf9cc672e7c34a4adf7b17c0a9c17d15d/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2", size = 218674, upload-time = "2026-03-15T18:50:54.102Z" },
+    { url = "https://files.pythonhosted.org/packages/af/90/25f6ab406659286be929fd89ab0e78e38aa183fc374e03aa3c12d730af8a/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff", size = 215259, upload-time = "2026-03-15T18:50:55.616Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ef/79a463eb0fff7f96afa04c1d4c51f8fc85426f918db467854bfb6a569ce3/charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5", size = 207276, upload-time = "2026-03-15T18:50:57.054Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/72/d0426afec4b71dc159fa6b4e68f868cd5a3ecd918fec5813a15d292a7d10/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0", size = 195161, upload-time = "2026-03-15T18:50:58.686Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/18/c82b06a68bfcb6ce55e508225d210c7e6a4ea122bfc0748892f3dc4e8e11/charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a", size = 203452, upload-time = "2026-03-15T18:51:00.196Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d6/0c25979b92f8adafdbb946160348d8d44aa60ce99afdc27df524379875cb/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2", size = 202272, upload-time = "2026-03-15T18:51:01.703Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/7fea3e8fe84136bebbac715dd1221cc25c173c57a699c030ab9b8900cbb7/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5", size = 195622, upload-time = "2026-03-15T18:51:03.526Z" },
+    { url = "https://files.pythonhosted.org/packages/57/8a/d6f7fd5cb96c58ef2f681424fbca01264461336d2a7fc875e4446b1f1346/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6", size = 220056, upload-time = "2026-03-15T18:51:05.269Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/478cdda782c8c9c3fb5da3cc72dd7f331f031e7f1363a893cdd6ca0f8de0/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d", size = 203751, upload-time = "2026-03-15T18:51:06.858Z" },
+    { url = "https://files.pythonhosted.org/packages/75/fc/cc2fcac943939c8e4d8791abfa139f685e5150cae9f94b60f12520feaa9b/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2", size = 216563, upload-time = "2026-03-15T18:51:08.564Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b7/a4add1d9a5f68f3d037261aecca83abdb0ab15960a3591d340e829b37298/charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923", size = 209265, upload-time = "2026-03-15T18:51:10.312Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/18/c094561b5d64a24277707698e54b7f67bd17a4f857bbfbb1072bba07c8bf/charset_normalizer-3.4.6-cp312-cp312-win32.whl", hash = "sha256:c2274ca724536f173122f36c98ce188fd24ce3dad886ec2b7af859518ce008a4", size = 144229, upload-time = "2026-03-15T18:51:11.694Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/20/0567efb3a8fd481b8f34f739ebddc098ed062a59fed41a8d193a61939e8f/charset_normalizer-3.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:c8ae56368f8cc97c7e40a7ee18e1cedaf8e780cd8bc5ed5ac8b81f238614facb", size = 154277, upload-time = "2026-03-15T18:51:13.004Z" },
+    { url = "https://files.pythonhosted.org/packages/15/57/28d79b44b51933119e21f65479d0864a8d5893e494cf5daab15df0247c17/charset_normalizer-3.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:899d28f422116b08be5118ef350c292b36fc15ec2daeb9ea987c89281c7bb5c4", size = 142817, upload-time = "2026-03-15T18:51:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/1d/4fdabeef4e231153b6ed7567602f3b68265ec4e5b76d6024cf647d43d981/charset_normalizer-3.4.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f", size = 294823, upload-time = "2026-03-15T18:51:15.755Z" },
+    { url = "https://files.pythonhosted.org/packages/47/7b/20e809b89c69d37be748d98e84dce6820bf663cf19cf6b942c951a3e8f41/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843", size = 198527, upload-time = "2026-03-15T18:51:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/4f8d27527d59c039dce6f7622593cdcd3d70a8504d87d09eb11e9fdc6062/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf", size = 218388, upload-time = "2026-03-15T18:51:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/9b/4770ccb3e491a9bacf1c46cc8b812214fe367c86a96353ccc6daf87b01ec/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8", size = 214563, upload-time = "2026-03-15T18:51:20.374Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/58/a199d245894b12db0b957d627516c78e055adc3a0d978bc7f65ddaf7c399/charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9", size = 206587, upload-time = "2026-03-15T18:51:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/3def227f1ec56f5c69dfc8392b8bd63b11a18ca8178d9211d7cc5e5e4f27/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88", size = 194724, upload-time = "2026-03-15T18:51:23.508Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ab/9318352e220c05efd31c2779a23b50969dc94b985a2efa643ed9077bfca5/charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84", size = 202956, upload-time = "2026-03-15T18:51:25.239Z" },
+    { url = "https://files.pythonhosted.org/packages/75/13/f3550a3ac25b70f87ac98c40d3199a8503676c2f1620efbf8d42095cfc40/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd", size = 201923, upload-time = "2026-03-15T18:51:26.682Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/db/c5c643b912740b45e8eec21de1bbab8e7fc085944d37e1e709d3dcd9d72f/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c", size = 195366, upload-time = "2026-03-15T18:51:28.129Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/67/3b1c62744f9b2448443e0eb160d8b001c849ec3fef591e012eda6484787c/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194", size = 219752, upload-time = "2026-03-15T18:51:29.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/98/32ffbaf7f0366ffb0445930b87d103f6b406bc2c271563644bde8a2b1093/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc", size = 203296, upload-time = "2026-03-15T18:51:30.921Z" },
+    { url = "https://files.pythonhosted.org/packages/41/12/5d308c1bbe60cabb0c5ef511574a647067e2a1f631bc8634fcafaccd8293/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f", size = 215956, upload-time = "2026-03-15T18:51:32.399Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e9/5f85f6c5e20669dbe56b165c67b0260547dea97dba7e187938833d791687/charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2", size = 208652, upload-time = "2026-03-15T18:51:34.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/11/897052ea6af56df3eef3ca94edafee410ca699ca0c7b87960ad19932c55e/charset_normalizer-3.4.6-cp313-cp313-win32.whl", hash = "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d", size = 143940, upload-time = "2026-03-15T18:51:36.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5c/724b6b363603e419829f561c854b87ed7c7e31231a7908708ac086cdf3e2/charset_normalizer-3.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389", size = 154101, upload-time = "2026-03-15T18:51:37.876Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a5/7abf15b4c0968e47020f9ca0935fb3274deb87cb288cd187cad92e8cdffd/charset_normalizer-3.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f", size = 143109, upload-time = "2026-03-15T18:51:39.565Z" },
+    { url = "https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8", size = 294458, upload-time = "2026-03-15T18:51:41.134Z" },
+    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421", size = 199277, upload-time = "2026-03-15T18:51:42.953Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2", size = 218758, upload-time = "2026-03-15T18:51:44.339Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30", size = 215299, upload-time = "2026-03-15T18:51:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db", size = 206811, upload-time = "2026-03-15T18:51:47.308Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8", size = 193706, upload-time = "2026-03-15T18:51:48.849Z" },
+    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815", size = 202706, upload-time = "2026-03-15T18:51:50.257Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a", size = 202497, upload-time = "2026-03-15T18:51:52.012Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43", size = 193511, upload-time = "2026-03-15T18:51:53.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0", size = 220133, upload-time = "2026-03-15T18:51:55.333Z" },
+    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1", size = 203035, upload-time = "2026-03-15T18:51:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f", size = 216321, upload-time = "2026-03-15T18:51:58.17Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815", size = 208973, upload-time = "2026-03-15T18:51:59.998Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/57/4ecff6d4ec8585342f0c71bc03efaa99cb7468f7c91a57b105bcd561cea8/charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d", size = 144610, upload-time = "2026-03-15T18:52:02.213Z" },
+    { url = "https://files.pythonhosted.org/packages/80/94/8434a02d9d7f168c25767c64671fead8d599744a05d6a6c877144c754246/charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f", size = 154962, upload-time = "2026-03-15T18:52:03.658Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4c/48f2cdbfd923026503dfd67ccea45c94fd8fe988d9056b468579c66ed62b/charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e", size = 143595, upload-time = "2026-03-15T18:52:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/31/93/8878be7569f87b14f1d52032946131bcb6ebbd8af3e20446bc04053dc3f1/charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866", size = 314828, upload-time = "2026-03-15T18:52:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc", size = 208138, upload-time = "2026-03-15T18:52:08.239Z" },
+    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e", size = 224679, upload-time = "2026-03-15T18:52:10.043Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077", size = 223475, upload-time = "2026-03-15T18:52:11.854Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f", size = 215230, upload-time = "2026-03-15T18:52:13.325Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e", size = 199045, upload-time = "2026-03-15T18:52:14.752Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484", size = 211658, upload-time = "2026-03-15T18:52:16.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7", size = 210769, upload-time = "2026-03-15T18:52:17.782Z" },
+    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff", size = 201328, upload-time = "2026-03-15T18:52:19.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e", size = 225302, upload-time = "2026-03-15T18:52:21.043Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659", size = 211127, upload-time = "2026-03-15T18:52:22.491Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602", size = 222840, upload-time = "2026-03-15T18:52:24.113Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407", size = 216890, upload-time = "2026-03-15T18:52:25.541Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1a/05dacadb0978da72ee287b0143097db12f2e7e8d3ffc4647da07a383b0b7/charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579", size = 155379, upload-time = "2026-03-15T18:52:27.05Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7a/d269d834cb3a76291651256f3b9a5945e81d0a49ab9f4a498964e83c0416/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4", size = 169043, upload-time = "2026-03-15T18:52:28.502Z" },
+    { url = "https://files.pythonhosted.org/packages/23/06/28b29fba521a37a8932c6a84192175c34d49f84a6d4773fa63d05f9aff22/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c", size = 148523, upload-time = "2026-03-15T18:52:29.956Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455, upload-time = "2026-03-15T18:53:23.833Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -152,6 +225,7 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "requests" },
 ]
 
 [package.optional-dependencies]
@@ -177,6 +251,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
 ]
 provides-extras = ["dev"]
@@ -524,6 +599,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.7"
 source = { registry = "https://pypi.org/simple" }
@@ -588,4 +678,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]


### PR DESCRIPTION
## Imagineering Service — FLUX.2-pro Integration

Closes #12

### What's new

**Interface:** `IImagineeringService` ABC at `interfaces/imagineering.py` — single method `imagineer_house(slug)` following the same pattern as `IRoomClassifier`.

**Models:** `ImagineeringResult` (house-level container) and `ImagineeringPhoto` (per-photo result with filename, room_type, prompt_used, guidance_value, output_path, timestamp). Both frozen Pydantic BaseModels.

**Service:** `FluxImagineeringService` at `services/imagineering_service.py`:
- Reads room classifications from `outputs/houses/{slug}/room_classifications.json`
- For each classified photo, calls FLUX.2-pro API with room-type-aware style prompt
- Writes generated images to `outputs/houses/{slug}/imagineered/{room_type}/{photo}.png`
- Writes metadata to `outputs/houses/{slug}/imagineering_results.json`
- **Idempotent:** skips already-generated images
- **Retry logic:** exponential backoff with jitter for 429/5xx errors
- **Structured logging** via `logging.getLogger(__name__)`

**Prompt:** `prompts/imagineering_prompt.txt` — room-type-aware template using `string.Template` (same pattern as classification_prompt.txt). Includes the full architectural preservation instructions from EXP-001.

**Factory:** `create_imagineering_service()` in `core.py` — reads `FLUX_API_KEY`, `FLUX_ENDPOINT`, `FLUX_GUIDANCE` (all required, fail loudly), `FLUX_SEED` (optional).

**Tests:** 16 parametrized cases in `tests/test_imagineering.py`:
- Model serialization round-trips
- Successful generation with mocked API
- Idempotent skip behavior
- API error handling (retryable vs non-retryable)
- Missing data handling (no classifications, missing source photos)
- Factory env var validation

**Dependency:** `requests>=2.31.0` added to pyproject.toml.

### Patterns followed
- CLEAN architecture: interface → service → composition root
- NamedTuple + `@pytest.mark.parametrize` test pattern
- ADR-004 mocking boundary (mock `requests.post`)
- No hardcoded env var defaults
- `uv` for all package management