### PR TITLE
feat: LLM-based text filter service

### DIFF
--- a/.squad/agents/zero/history.md
+++ b/.squad/agents/zero/history.md
@@ -35,3 +35,16 @@
 - Standalone CLI: `python -m src.evaluation.deterministic --house {slug}` — uses `load_storage_paths()` with graceful fallback.
 - Tests: 44 parametrised cases, NamedTuple + `@pytest.mark.parametrize`, zero class-based tests. `tmp_path` fixture for filesystem cases.
 - VCR cassette structure placeholder at `tests/fixtures/cassettes/` — record with `pytest --record-mode=new_episodes` once API keys are available.
+
+### 2026-03-24: Distance calculator service (Issue #11, PR #52)
+
+- **IDistanceCalculator** interface at `interfaces/distance_calculator.py` — ABC with `calculate_distances(slug) -> DistanceResult`.
+- **TravelTime** and **DistanceResult** models at `models/distance.py` — frozen Pydantic BaseModels with `to_summary_dict()` and `to_detailed_dict()`.
+- **GoogleMapsDistanceCalculator** at `services/distance_calculator.py` — calls Google Maps Distance Matrix API via `requests.get`. Uses `_call_distance_api` as the mocking boundary.
+- Address extraction from `listing.txt`: regex patterns for `Address:`, `Adres:`, `Location:` labels, falls back to first non-empty line.
+- Idempotent via `distances.json` + SHA-256 config hash comparison — recalculates only when destinations config changes.
+- **Factory** `create_distance_calculator()` in `core.py` — requires `GOOGLE_MAPS_API_KEY` (no default, fails loudly).
+- **`load_distance_config()`** in `config.py` reads `distance.destinations` from criteria.yaml.
+- Sample destinations (Amsterdam Central, Office) added to `config/criteria.yaml`.
+- Tests: 21 parametrised cases, NamedTuple + `@pytest.mark.parametrize`. Mocks `requests.get` at the service module boundary.
+- `House` model already has `distances: dict[str, int]` and `with_distance()` — ready for pipeline integration.

--- a/backend/config/criteria.yaml
+++ b/backend/config/criteria.yaml
@@ -20,3 +20,14 @@ text_filter:
   excluded_keywords:
     - "highway"
     - "industrial"
+
+llm_text_filter:
+  p1_criteria:
+    - "has a private garden or outdoor space"
+    - "has at least 3 bedrooms"
+  p2_criteria:
+    - "has a garage or covered parking"
+    - "has a modern kitchen with dishwasher"
+  excluded_criteria:
+    - "located near a highway or industrial area"
+    - "requires major renovation"

--- a/backend/prompts/text_analysis_prompt.txt
+++ b/backend/prompts/text_analysis_prompt.txt
@@ -1,0 +1,25 @@
+You are evaluating a real-estate listing against a set of criteria.
+
+LISTING TEXT:
+$listing_text
+
+CRITERIA TO EVALUATE:
+$criteria_list
+
+For each criterion, determine whether the listing text indicates the criterion is met.
+Consider both explicit mentions and strong implications from the text.
+Be conservative — only mark a criterion as met if the text clearly supports it.
+
+Respond with ONLY a JSON object (no extra text) with exactly this structure:
+{
+  "evaluations": [
+    {
+      "criterion_name": "the criterion text exactly as given",
+      "met": true or false,
+      "confidence": a number between 0.0 and 1.0,
+      "reasoning": "one-sentence explanation of why the criterion is or is not met"
+    }
+  ]
+}
+
+Include one entry for every criterion listed above, in the same order.

--- a/backend/src/core.py
+++ b/backend/src/core.py
@@ -6,6 +6,7 @@ import os
 
 from .config import load_storage_paths
 from .interfaces.data_source import IDataSource
+from .interfaces.filter import IFilter
 from .interfaces.imagineering import IImagineeringService
 from .interfaces.room_classifier import IRoomClassifier
 from .services.azure_openai_service import AzureOpenAIService
@@ -13,6 +14,7 @@ from .services.house_repository import HouseRepository
 from .services.imagineering_service import FluxImagineeringService
 from .services.local_storage import LocalStorage
 from .services.room_classifier import AzureOpenAIRoomClassifier
+from .services.text_filter_service import LLMTextFilterService
 
 
 def create_storage() -> IDataSource:
@@ -90,4 +92,21 @@ def create_imagineering_service() -> IImagineeringService:
         output_dir=output_dir,
         guidance=float(os.environ["FLUX_GUIDANCE"]),
         default_seed=int(seed_raw) if seed_raw is not None else None,
+    )
+
+
+def create_llm_text_filter() -> IFilter:
+    """Create an LLM-based text filter wired to Azure OpenAI and storage paths.
+
+    Returns:
+        A configured IFilter implementation for LLM text analysis.
+
+    Raises:
+        MissingConfigError: If Azure OpenAI credentials are not configured.
+    """
+    llm_service = AzureOpenAIService()
+    _, output_dir = load_storage_paths()
+    return LLMTextFilterService(
+        llm_service=llm_service,
+        output_dir=output_dir,
     )

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -9,8 +9,10 @@ from .house import FilterResult, House, HouseMetadata, HouseStatus
 from .imagineering import ImagineeringPhoto, ImagineeringResult
 from .llm import LLMResponse
 from .room import Photo, Room, RoomType
+from .text_analysis import CriterionResult, TextAnalysis
 
 __all__ = [
+    "CriterionResult",
     "FilterResult",
     "House",
     "HouseClassifications",
@@ -23,4 +25,5 @@ __all__ = [
     "PhotoClassification",
     "Room",
     "RoomType",
+    "TextAnalysis",
 ]

--- a/backend/src/models/text_analysis.py
+++ b/backend/src/models/text_analysis.py
@@ -1,0 +1,59 @@
+"""Text analysis result models.
+
+Pure data structures for LLM-based text filter outputs.
+Used by the LLM text filter service to represent per-criterion
+evaluation results and their mapping to FilterResult.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .house import FilterResult
+
+
+class CriterionResult(BaseModel):
+    """Evaluation result for a single criterion against listing text."""
+
+    criterion_name: str = Field(description="Name of the criterion evaluated")
+    category: str = Field(description="Priority category: p1, p2, or excluded")
+    met: bool = Field(description="Whether the criterion is met by the listing")
+    confidence: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="LLM confidence in the evaluation (0.0–1.0)",
+    )
+    reasoning: str = Field(description="LLM reasoning for the evaluation")
+
+    model_config = {"frozen": True}
+
+
+class TextAnalysis(BaseModel):
+    """Persisted text analysis result for a single house."""
+
+    slug: str = Field(description="House identifier")
+    criteria_hash: str = Field(
+        description="SHA-256 hash of the criteria config to detect drift",
+    )
+    evaluations: list[CriterionResult] = Field(
+        default_factory=list,
+        description="Per-criterion evaluation results",
+    )
+
+    model_config = {"frozen": True}
+
+    def to_filter_result(self) -> FilterResult:
+        """Convert text analysis evaluations to a FilterResult."""
+        p1: dict[str, bool] = {}
+        p2: dict[str, bool] = {}
+        excluded: dict[str, bool] = {}
+
+        for ev in self.evaluations:
+            if ev.category == "p1":
+                p1[ev.criterion_name] = ev.met
+            elif ev.category == "p2":
+                p2[ev.criterion_name] = ev.met
+            elif ev.category == "excluded":
+                excluded[ev.criterion_name] = ev.met
+
+        return FilterResult(p1=p1, p2=p2, excluded=excluded)

--- a/backend/src/services/__init__.py
+++ b/backend/src/services/__init__.py
@@ -4,10 +4,12 @@ from .azure_openai_service import AzureOpenAIService
 from .imagineering_service import FluxImagineeringService
 from .local_storage import LocalStorage
 from .room_classifier import AzureOpenAIRoomClassifier
+from .text_filter_service import LLMTextFilterService
 
 __all__ = [
     "AzureOpenAIService",
     "AzureOpenAIRoomClassifier",
     "FluxImagineeringService",
+    "LLMTextFilterService",
     "LocalStorage",
 ]

--- a/backend/src/services/text_filter_service.py
+++ b/backend/src/services/text_filter_service.py
@@ -1,0 +1,226 @@
+"""LLM-based text filter service — evaluates listing text against criteria using AI.
+
+Sends listing text and criteria to an ILLMService for structured evaluation.
+Results are cached to outputs/houses/{slug}/text_analysis.json and reused
+when the criteria config hasn't changed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from string import Template
+from typing import Any
+
+from pydantic import Field
+
+from ..interfaces.filter import IFilter
+from ..interfaces.llm_service import ILLMService
+from ..models.house import FilterResult, House
+from ..models.llm import LLMResponse
+from ..models.text_analysis import CriterionResult, TextAnalysis
+
+logger = logging.getLogger(__name__)
+
+_PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
+
+
+# ------------------------------------------------------------------
+# Internal LLM response models (private to this service)
+# ------------------------------------------------------------------
+
+
+class _CriterionEval(LLMResponse):
+    """LLM's evaluation of a single criterion."""
+
+    criterion_name: str
+    met: bool
+    confidence: float = Field(ge=0.0, le=1.0)
+    reasoning: str
+
+
+class _TextAnalysisResult(LLMResponse):
+    """Structured-output wrapper returned by the LLM."""
+
+    evaluations: list[_CriterionEval]
+
+
+# ------------------------------------------------------------------
+# Service
+# ------------------------------------------------------------------
+
+
+class LLMTextFilterService(IFilter):
+    """Filters houses by evaluating listing text against criteria via an LLM.
+
+    Args:
+        llm_service: LLM service for structured text completions.
+        output_dir: Root directory for cached analysis output.
+    """
+
+    def __init__(
+        self,
+        llm_service: ILLMService,
+        output_dir: Path,
+    ) -> None:
+        self._llm_service = llm_service
+        self._output_dir = output_dir
+        self._prompt_template = Template(
+            (_PROMPTS_DIR / "text_analysis_prompt.txt").read_text(encoding="utf-8")
+        )
+
+    @property
+    def name(self) -> str:
+        return "llm_text_filter"
+
+    def filter(
+        self,
+        houses: list[House],
+        criteria: dict[str, Any],
+    ) -> dict[str, FilterResult]:
+        """Evaluate houses against criteria using LLM text analysis.
+
+        Args:
+            houses: List of houses to evaluate.
+            criteria: Criteria dict with p1_criteria, p2_criteria, excluded_criteria.
+
+        Returns:
+            Mapping of slug -> FilterResult.
+        """
+        criteria_hash = _compute_criteria_hash(criteria)
+        all_criteria = _build_criteria_list(criteria)
+
+        results: dict[str, FilterResult] = {}
+        for house in houses:
+            analysis = self._analyze_house(house, all_criteria, criteria_hash)
+            results[house.slug] = analysis.to_filter_result()
+        return results
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _analyze_house(
+        self,
+        house: House,
+        all_criteria: list[tuple[str, str]],
+        criteria_hash: str,
+    ) -> TextAnalysis:
+        """Analyze a single house, using cache when criteria are unchanged."""
+        output_file = self._output_dir / house.slug / "text_analysis.json"
+
+        cached = self._load_cached(output_file, criteria_hash)
+        if cached is not None:
+            logger.info("Using cached text analysis for '%s'", house.slug)
+            return cached
+
+        logger.info("Running LLM text analysis for '%s'", house.slug)
+        analysis = self._run_llm_analysis(house, all_criteria, criteria_hash)
+        self._save_results(output_file, analysis)
+        return analysis
+
+    def _load_cached(
+        self,
+        output_file: Path,
+        criteria_hash: str,
+    ) -> TextAnalysis | None:
+        """Load cached analysis if it exists and criteria haven't changed."""
+        if not output_file.exists():
+            return None
+
+        try:
+            data = json.loads(output_file.read_text(encoding="utf-8"))
+            analysis = TextAnalysis(**data)
+        except (json.JSONDecodeError, ValueError):
+            logger.warning("Corrupt cache file %s, will re-analyze", output_file)
+            return None
+
+        if analysis.criteria_hash != criteria_hash:
+            logger.info("Criteria changed for '%s', will re-analyze", analysis.slug)
+            return None
+
+        return analysis
+
+    def _run_llm_analysis(
+        self,
+        house: House,
+        all_criteria: list[tuple[str, str]],
+        criteria_hash: str,
+    ) -> TextAnalysis:
+        """Send listing text + criteria to the LLM and parse the response."""
+        criteria_text = "\n".join(
+            f"- [{category}] {criterion}" for criterion, category in all_criteria
+        )
+        prompt = self._prompt_template.substitute(
+            listing_text=house.listing_text,
+            criteria_list=criteria_text,
+        )
+
+        response = self._llm_service.complete_structured(prompt, _TextAnalysisResult)
+        assert isinstance(response, _TextAnalysisResult)
+
+        evaluations = [
+            CriterionResult(
+                criterion_name=ev.criterion_name,
+                category=self._resolve_category(ev.criterion_name, all_criteria),
+                met=ev.met,
+                confidence=ev.confidence,
+                reasoning=ev.reasoning,
+            )
+            for ev in response.evaluations
+        ]
+
+        return TextAnalysis(
+            slug=house.slug,
+            criteria_hash=criteria_hash,
+            evaluations=evaluations,
+        )
+
+    def _resolve_category(
+        self,
+        criterion_name: str,
+        all_criteria: list[tuple[str, str]],
+    ) -> str:
+        """Look up the category for a criterion name from the criteria list."""
+        for criterion, category in all_criteria:
+            if criterion == criterion_name:
+                return category
+        logger.warning(
+            "LLM returned unknown criterion '%s', defaulting to 'p2'",
+            criterion_name,
+        )
+        return "p2"
+
+    def _save_results(self, output_file: Path, analysis: TextAnalysis) -> None:
+        """Write analysis to JSON cache file."""
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(
+            json.dumps(analysis.model_dump(), indent=2) + "\n",
+            encoding="utf-8",
+        )
+        logger.info("Saved text analysis to %s", output_file)
+
+
+# ------------------------------------------------------------------
+# Module-level helpers
+# ------------------------------------------------------------------
+
+
+def _compute_criteria_hash(criteria: dict[str, Any]) -> str:
+    """Compute a stable SHA-256 hash of the criteria dict."""
+    canonical = json.dumps(criteria, sort_keys=True)
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _build_criteria_list(criteria: dict[str, Any]) -> list[tuple[str, str]]:
+    """Build a flat list of (criterion_text, category) tuples from criteria config."""
+    result: list[tuple[str, str]] = []
+    for criterion in criteria.get("p1_criteria", []):
+        result.append((criterion, "p1"))
+    for criterion in criteria.get("p2_criteria", []):
+        result.append((criterion, "p2"))
+    for criterion in criteria.get("excluded_criteria", []):
+        result.append((criterion, "excluded"))
+    return result

--- a/backend/tests/test_text_filter_service.py
+++ b/backend/tests/test_text_filter_service.py
@@ -1,0 +1,596 @@
+"""Unit tests for the LLM text filter service."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, NamedTuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.models.house import House
+from src.models.text_analysis import CriterionResult, TextAnalysis
+from src.services.text_filter_service import (
+    LLMTextFilterService,
+    _build_criteria_list,
+    _compute_criteria_hash,
+    _CriterionEval,
+    _TextAnalysisResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CRITERIA: dict[str, Any] = {
+    "p1_criteria": [
+        "has a private garden or outdoor space",
+        "has at least 3 bedrooms",
+    ],
+    "p2_criteria": [
+        "has a garage or covered parking",
+    ],
+    "excluded_criteria": [
+        "located near a highway or industrial area",
+    ],
+}
+
+_SAMPLE_LISTING = (
+    "Beautiful 4-bedroom house with a spacious private garden. "
+    "Modern kitchen with dishwasher. Quiet residential neighbourhood."
+)
+
+
+def _make_house(slug: str = "test-house", listing_text: str = _SAMPLE_LISTING) -> House:
+    """Create a minimal House for testing."""
+    return House(slug=slug, listing_text=listing_text)
+
+
+def _make_llm_response(
+    evals: list[dict[str, Any]] | None = None,
+) -> _TextAnalysisResult:
+    """Build a fake LLM structured response."""
+    if evals is None:
+        evals = [
+            {
+                "criterion_name": "has a private garden or outdoor space",
+                "met": True,
+                "confidence": 0.95,
+                "reasoning": "Listing mentions a spacious private garden.",
+            },
+            {
+                "criterion_name": "has at least 3 bedrooms",
+                "met": True,
+                "confidence": 0.90,
+                "reasoning": "Listing says 4-bedroom house.",
+            },
+            {
+                "criterion_name": "has a garage or covered parking",
+                "met": False,
+                "confidence": 0.80,
+                "reasoning": "No mention of garage or parking.",
+            },
+            {
+                "criterion_name": "located near a highway or industrial area",
+                "met": False,
+                "confidence": 0.85,
+                "reasoning": "Described as quiet residential neighbourhood.",
+            },
+        ]
+    return _TextAnalysisResult(
+        evaluations=[_CriterionEval(**ev) for ev in evals],
+    )
+
+
+def _make_service(
+    tmp_path: Path,
+    llm_response: _TextAnalysisResult | None = None,
+) -> tuple[LLMTextFilterService, MagicMock]:
+    """Create an LLMTextFilterService with a mocked ILLMService."""
+    mock_llm = MagicMock()
+    mock_llm.complete_structured.return_value = (
+        llm_response if llm_response is not None else _make_llm_response()
+    )
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True)
+    service = LLMTextFilterService(
+        llm_service=mock_llm,
+        output_dir=output_dir,
+    )
+    return service, mock_llm
+
+
+# ---------------------------------------------------------------------------
+# Criteria hash
+# ---------------------------------------------------------------------------
+
+
+class CriteriaHashCase(NamedTuple):
+    """Test case for criteria hash computation."""
+
+    description: str
+    criteria_a: dict[str, Any]
+    criteria_b: dict[str, Any]
+    should_match: bool
+
+
+CRITERIA_HASH_CASES = [
+    CriteriaHashCase(
+        description="identical criteria produce the same hash",
+        criteria_a={"p1_criteria": ["garden"]},
+        criteria_b={"p1_criteria": ["garden"]},
+        should_match=True,
+    ),
+    CriteriaHashCase(
+        description="different criteria produce different hashes",
+        criteria_a={"p1_criteria": ["garden"]},
+        criteria_b={"p1_criteria": ["pool"]},
+        should_match=False,
+    ),
+    CriteriaHashCase(
+        description="key order does not affect hash",
+        criteria_a={"p1_criteria": ["a"], "p2_criteria": ["b"]},
+        criteria_b={"p2_criteria": ["b"], "p1_criteria": ["a"]},
+        should_match=True,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "description, criteria_a, criteria_b, should_match",
+    CRITERIA_HASH_CASES,
+)
+def test_criteria_hash(
+    description: str,
+    criteria_a: dict[str, Any],
+    criteria_b: dict[str, Any],
+    should_match: bool,
+) -> None:
+    hash_a = _compute_criteria_hash(criteria_a)
+    hash_b = _compute_criteria_hash(criteria_b)
+    if should_match:
+        assert hash_a == hash_b
+    else:
+        assert hash_a != hash_b
+
+
+# ---------------------------------------------------------------------------
+# Criteria list building
+# ---------------------------------------------------------------------------
+
+
+class CriteriaListCase(NamedTuple):
+    """Test case for building the flat criteria list."""
+
+    description: str
+    criteria: dict[str, Any]
+    expected: list[tuple[str, str]]
+
+
+CRITERIA_LIST_CASES = [
+    CriteriaListCase(
+        description="all categories are included",
+        criteria={
+            "p1_criteria": ["garden"],
+            "p2_criteria": ["garage"],
+            "excluded_criteria": ["highway"],
+        },
+        expected=[("garden", "p1"), ("garage", "p2"), ("highway", "excluded")],
+    ),
+    CriteriaListCase(
+        description="missing categories default to empty",
+        criteria={"p1_criteria": ["garden"]},
+        expected=[("garden", "p1")],
+    ),
+    CriteriaListCase(
+        description="empty criteria dict produces empty list",
+        criteria={},
+        expected=[],
+    ),
+]
+
+
+@pytest.mark.parametrize("description, criteria, expected", CRITERIA_LIST_CASES)
+def test_build_criteria_list(
+    description: str,
+    criteria: dict[str, Any],
+    expected: list[tuple[str, str]],
+) -> None:
+    result = _build_criteria_list(criteria)
+    assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# FilterResult mapping
+# ---------------------------------------------------------------------------
+
+
+class FilterResultMappingCase(NamedTuple):
+    """Test case for TextAnalysis -> FilterResult conversion."""
+
+    description: str
+    evaluations: list[CriterionResult]
+    expected_p1: dict[str, bool]
+    expected_p2: dict[str, bool]
+    expected_excluded: dict[str, bool]
+
+
+FILTER_RESULT_CASES = [
+    FilterResultMappingCase(
+        description="p1/p2/excluded correctly populated",
+        evaluations=[
+            CriterionResult(
+                criterion_name="garden",
+                category="p1",
+                met=True,
+                confidence=0.9,
+                reasoning="Has garden.",
+            ),
+            CriterionResult(
+                criterion_name="garage",
+                category="p2",
+                met=False,
+                confidence=0.8,
+                reasoning="No garage.",
+            ),
+            CriterionResult(
+                criterion_name="highway",
+                category="excluded",
+                met=False,
+                confidence=0.7,
+                reasoning="Not near highway.",
+            ),
+        ],
+        expected_p1={"garden": True},
+        expected_p2={"garage": False},
+        expected_excluded={"highway": False},
+    ),
+    FilterResultMappingCase(
+        description="empty evaluations produce empty FilterResult",
+        evaluations=[],
+        expected_p1={},
+        expected_p2={},
+        expected_excluded={},
+    ),
+    FilterResultMappingCase(
+        description="multiple p1 criteria are all included",
+        evaluations=[
+            CriterionResult(
+                criterion_name="garden",
+                category="p1",
+                met=True,
+                confidence=0.9,
+                reasoning="Yes.",
+            ),
+            CriterionResult(
+                criterion_name="3 bedrooms",
+                category="p1",
+                met=False,
+                confidence=0.6,
+                reasoning="Only 2.",
+            ),
+        ],
+        expected_p1={"garden": True, "3 bedrooms": False},
+        expected_p2={},
+        expected_excluded={},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "description, evaluations, expected_p1, expected_p2, expected_excluded",
+    FILTER_RESULT_CASES,
+)
+def test_filter_result_mapping(
+    description: str,
+    evaluations: list[CriterionResult],
+    expected_p1: dict[str, bool],
+    expected_p2: dict[str, bool],
+    expected_excluded: dict[str, bool],
+) -> None:
+    analysis = TextAnalysis(slug="test", criteria_hash="abc", evaluations=evaluations)
+    result = analysis.to_filter_result()
+    assert result.p1 == expected_p1
+    assert result.p2 == expected_p2
+    assert result.excluded == expected_excluded
+
+
+# ---------------------------------------------------------------------------
+# Full filter flow
+# ---------------------------------------------------------------------------
+
+
+class FilterFlowCase(NamedTuple):
+    """Test case for the full LLM text filter flow."""
+
+    description: str
+    listing_text: str
+    llm_evals: list[dict[str, Any]]
+    expected_p1_values: list[bool]
+    expected_excluded_values: list[bool]
+
+
+FILTER_FLOW_CASES = [
+    FilterFlowCase(
+        description="house passes when all p1 met and no excluded",
+        listing_text=_SAMPLE_LISTING,
+        llm_evals=[
+            {
+                "criterion_name": "has a private garden or outdoor space",
+                "met": True,
+                "confidence": 0.95,
+                "reasoning": "Has garden.",
+            },
+            {
+                "criterion_name": "has at least 3 bedrooms",
+                "met": True,
+                "confidence": 0.90,
+                "reasoning": "4 bedrooms.",
+            },
+            {
+                "criterion_name": "has a garage or covered parking",
+                "met": False,
+                "confidence": 0.80,
+                "reasoning": "No garage.",
+            },
+            {
+                "criterion_name": "located near a highway or industrial area",
+                "met": False,
+                "confidence": 0.85,
+                "reasoning": "Quiet area.",
+            },
+        ],
+        expected_p1_values=[True, True],
+        expected_excluded_values=[False],
+    ),
+    FilterFlowCase(
+        description="house excluded when excluded criterion is met",
+        listing_text="Near highway, industrial zone. 2 bedrooms.",
+        llm_evals=[
+            {
+                "criterion_name": "has a private garden or outdoor space",
+                "met": False,
+                "confidence": 0.70,
+                "reasoning": "No garden.",
+            },
+            {
+                "criterion_name": "has at least 3 bedrooms",
+                "met": False,
+                "confidence": 0.85,
+                "reasoning": "Only 2 bedrooms.",
+            },
+            {
+                "criterion_name": "has a garage or covered parking",
+                "met": False,
+                "confidence": 0.90,
+                "reasoning": "No garage.",
+            },
+            {
+                "criterion_name": "located near a highway or industrial area",
+                "met": True,
+                "confidence": 0.95,
+                "reasoning": "Near highway.",
+            },
+        ],
+        expected_p1_values=[False, False],
+        expected_excluded_values=[True],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "description, listing_text, llm_evals, expected_p1_values, expected_excluded_values",
+    FILTER_FLOW_CASES,
+)
+def test_filter_flow(
+    description: str,
+    listing_text: str,
+    llm_evals: list[dict[str, Any]],
+    expected_p1_values: list[bool],
+    expected_excluded_values: list[bool],
+    tmp_path: Path,
+) -> None:
+    response = _make_llm_response(llm_evals)
+    service, mock_llm = _make_service(tmp_path, response)
+    house = _make_house(listing_text=listing_text)
+
+    results = service.filter([house], _SAMPLE_CRITERIA)
+
+    assert house.slug in results
+    fr = results[house.slug]
+    assert list(fr.p1.values()) == expected_p1_values
+    assert list(fr.excluded.values()) == expected_excluded_values
+    mock_llm.complete_structured.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Caching behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_skips_llm_call(tmp_path: Path) -> None:
+    """When cached analysis exists with matching criteria hash, skip the LLM."""
+    service, mock_llm = _make_service(tmp_path)
+    house = _make_house()
+
+    # First call — hits the LLM
+    service.filter([house], _SAMPLE_CRITERIA)
+    assert mock_llm.complete_structured.call_count == 1
+
+    # Second call — should use cache
+    service.filter([house], _SAMPLE_CRITERIA)
+    assert mock_llm.complete_structured.call_count == 1
+
+
+def test_criteria_drift_triggers_reanalysis(tmp_path: Path) -> None:
+    """When criteria change, the cached result should be ignored."""
+    service, mock_llm = _make_service(tmp_path)
+    house = _make_house()
+
+    # First call with original criteria
+    service.filter([house], _SAMPLE_CRITERIA)
+    assert mock_llm.complete_structured.call_count == 1
+
+    # Second call with different criteria
+    changed_criteria = {
+        "p1_criteria": ["has a swimming pool"],
+        "p2_criteria": [],
+        "excluded_criteria": [],
+    }
+    # Update the LLM mock for the new criteria
+    mock_llm.complete_structured.return_value = _TextAnalysisResult(
+        evaluations=[
+            _CriterionEval(
+                criterion_name="has a swimming pool",
+                met=False,
+                confidence=0.70,
+                reasoning="No pool mentioned.",
+            ),
+        ],
+    )
+    service.filter([house], changed_criteria)
+    assert mock_llm.complete_structured.call_count == 2
+
+
+def test_corrupt_cache_triggers_reanalysis(tmp_path: Path) -> None:
+    """When the cache file is corrupt JSON, the service should re-analyze."""
+    service, mock_llm = _make_service(tmp_path)
+    house = _make_house()
+
+    # Write corrupt cache
+    cache_file = tmp_path / "output" / house.slug / "text_analysis.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text("{ not valid json", encoding="utf-8")
+
+    service.filter([house], _SAMPLE_CRITERIA)
+    assert mock_llm.complete_structured.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cache file persistence
+# ---------------------------------------------------------------------------
+
+
+def test_results_written_to_cache_file(tmp_path: Path) -> None:
+    """Filter results are persisted to the expected output file."""
+    service, _ = _make_service(tmp_path)
+    house = _make_house()
+
+    service.filter([house], _SAMPLE_CRITERIA)
+
+    cache_file = tmp_path / "output" / house.slug / "text_analysis.json"
+    assert cache_file.exists()
+
+    data = json.loads(cache_file.read_text(encoding="utf-8"))
+    analysis = TextAnalysis(**data)
+    assert analysis.slug == house.slug
+    assert len(analysis.evaluations) == 4
+
+
+# ---------------------------------------------------------------------------
+# Model serialization
+# ---------------------------------------------------------------------------
+
+
+class ModelSerializationCase(NamedTuple):
+    """Test case for text analysis model round-trip."""
+
+    description: str
+    slug: str
+    n_evaluations: int
+
+
+MODEL_SERIALIZATION_CASES = [
+    ModelSerializationCase(
+        description="TextAnalysis round-trips through JSON",
+        slug="canal-house",
+        n_evaluations=3,
+    ),
+    ModelSerializationCase(
+        description="empty evaluations list round-trips",
+        slug="empty-house",
+        n_evaluations=0,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "description, slug, n_evaluations",
+    MODEL_SERIALIZATION_CASES,
+)
+def test_model_serialization(
+    description: str,
+    slug: str,
+    n_evaluations: int,
+) -> None:
+    evaluations = [
+        CriterionResult(
+            criterion_name=f"criterion_{i}",
+            category="p1",
+            met=i % 2 == 0,
+            confidence=0.8,
+            reasoning=f"Reason {i}",
+        )
+        for i in range(n_evaluations)
+    ]
+    analysis = TextAnalysis(
+        slug=slug,
+        criteria_hash="abc123",
+        evaluations=evaluations,
+    )
+    data = analysis.model_dump()
+    restored = TextAnalysis(**data)
+    assert restored == analysis
+    assert len(restored.evaluations) == n_evaluations
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_llm_error_propagates(tmp_path: Path) -> None:
+    """LLM service errors should propagate to the caller."""
+    mock_llm = MagicMock()
+    mock_llm.complete_structured.side_effect = RuntimeError("LLM unavailable")
+    output_dir = tmp_path / "output"
+    output_dir.mkdir(parents=True)
+    service = LLMTextFilterService(llm_service=mock_llm, output_dir=output_dir)
+    house = _make_house()
+
+    with pytest.raises(RuntimeError, match="LLM unavailable"):
+        service.filter([house], _SAMPLE_CRITERIA)
+
+
+# ---------------------------------------------------------------------------
+# Multiple houses
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_houses_processed(tmp_path: Path) -> None:
+    """Each house gets its own analysis and cache file."""
+    service, mock_llm = _make_service(tmp_path)
+    houses = [_make_house(slug="house-a"), _make_house(slug="house-b")]
+
+    results = service.filter(houses, _SAMPLE_CRITERIA)
+
+    assert len(results) == 2
+    assert "house-a" in results
+    assert "house-b" in results
+    assert mock_llm.complete_structured.call_count == 2
+
+    # Both cache files should exist
+    assert (tmp_path / "output" / "house-a" / "text_analysis.json").exists()
+    assert (tmp_path / "output" / "house-b" / "text_analysis.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Name property
+# ---------------------------------------------------------------------------
+
+
+def test_name_property(tmp_path: Path) -> None:
+    """Service reports 'llm_text_filter' as its name."""
+    service, _ = _make_service(tmp_path)
+    assert service.name == "llm_text_filter"


### PR DESCRIPTION
## Summary

Implements the LLM-based text filter service (issue #8) — a smarter alternative to the keyword-based TextFilter that uses Azure OpenAI to evaluate listing text against natural-language criteria.

### What's included

- **`LLMTextFilterService`** (`services/text_filter_service.py`) — implements `IFilter`, uses `ILLMService.complete_structured()` with structured output
- **`TextAnalysis` + `CriterionResult`** (`models/text_analysis.py`) — frozen Pydantic models for persisted results, with `to_filter_result()`
- **Prompt template** (`prompts/text_analysis_prompt.txt`) — `string.Template` pattern (same as classification prompt)
- **Caching** — writes `text_analysis.json` per house, uses SHA-256 criteria hash to detect config drift
- **Factory** — `create_llm_text_filter()` in `core.py`
- **Config** — `llm_text_filter` section added to `criteria.yaml` with p1/p2/excluded criteria
- **Tests** — 20 parametrised test cases: filter flow, caching, drift detection, error handling, model serialization

### Patterns followed

- Constructor injection (`ILLMService` passed in)
- Internal LLM response models (`_CriterionEval`, `_TextAnalysisResult`) private to service
- Public output models in `models/`
- NamedTuple + `@pytest.mark.parametrize` (team standard)
- ADR-004 mocking approach (mock `ILLMService`, no real API calls)

Closes #8